### PR TITLE
Add missed brackets and semicolons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,18 +275,18 @@ in
                 where d.name = "Engineering"
                 yield d.deptno)
   yield e.name
-end
+end;
 
 let
   fun exists [] = false
-    | exists hd :: tl = true
+    | exists (hd :: tl) = true
 in
   from e in emps
   where exists (from d in depts
                 where d.deptno = e.deptno
                 andalso d.name = "Engineering")
   yield e.name
-end
+end;
 ```
 
 In the second query, note that the sub-query inside the `exists` is


### PR DESCRIPTION
It seems there are missed  brackets in the second query as it fails as 
```
Encountered " "::" ":: "" at line 3, column 17.
Was expecting one of:
    "_" ...
    <NON_NEGATIVE_INTEGER_LITERAL> ...
    <NEGATIVE_INTEGER_LITERAL> ...
    <REAL_LITERAL> ...
    <SCIENTIFIC_LITERAL> ...
    <QUOTED_STRING> ...
    <CHAR_LITERAL> ...
    "(" ...
    "{" ...
    "[" ...
    "=" ...
    <IDENTIFIER> ...
```

Also added semicolons (`;`) to make it easier to copy paste queries from example