### PR TITLE
Upgrades jline 3.12.1 -> 3.16.0, to give support for xrvt terminals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@ License.
     <java-diff.version>1.1.2</java-diff.version>
     <javacc-maven-plugin.version>3.0.0</javacc-maven-plugin.version>
     <javacc.version>7.0.5</javacc.version>
-    <jline.version>3.12.1</jline.version>
+    <jline.version>3.16.0</jline.version>
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>


### PR DESCRIPTION
Upgrades version for jline from 3.12.1 to 3.16.0. The upgrade is just to give support to xrvt terminal emulators (support given by 3.15.0 and later, in 3.16.0, other issues were fixed)